### PR TITLE
Make it more accessible

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,12 +40,13 @@
     </style>
   </head>
   <body>
-    <label class="toggle">
-      <span class="toggle-label">It's so over</span>
-      <input id="toggle" class="toggle-checkbox" type="checkbox" checked />
+    <div class="toggle" id="toggle">
+      <label for="over" class="toggle-label">It's so over</label>
+      <input id="over" name="over-back" class="toggle-radio" type="radio" />
       <div class="toggle-switch"></div>
-      <span class="toggle-label">We're so back</span>
-    </label>
+      <label for="back" class="toggle-label">We're so back</span>
+      <input id="back" name="over-back" class="toggle-radio" type="radio" checked />
+    </div>
     <div class="logo">
       <div>
         Concept by

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,9 @@ const conn = new PartySocket({
   room: "is-it-over-with-cursors",
 });
 
-const toggle = document.getElementById("toggle");
+const toggle = document.querySelector(".toggle-switch");
+const over = document.getElementById("over") as HTMLInputElement;
+const back = document.getElementById("back") as HTMLInputElement;
 let itwasme = false;
 
 console.log("toggle", toggle);
@@ -21,12 +23,22 @@ conn.addEventListener("message", (e) => {
   console.log("receive", message.over, "from", itwasme ? "me" : "them");
   if ("over" in message) {
     itwasme = message.sender === conn.id;
-    (toggle as any).checked = message.over;
+    if (message.over) {
+      over.checked = true;
+    } else {
+      back.checked = true;
+    }
   }
 });
 
-toggle?.addEventListener("click", (e) => {
-  const over = (e.target as any)?.checked;
-  console.log("send", over);
-  conn.send(JSON.stringify({ over }));
+// Click directly on the switch. Toggle the value.
+toggle?.addEventListener("click", () => {
+  console.log("send", !over.checked);
+  conn.send(JSON.stringify({ over: !over.checked }));
+});
+
+// Click on label or use keyboard/screen reader to change selection.
+over?.addEventListener("change", () => {
+  console.log("send", over.checked);
+  conn.send(JSON.stringify({ over: over.checked }));
 });

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,9 +1,9 @@
-/* 
-  We've already included normalize.css. 
+/*
+  We've already included normalize.css.
 
-  But we'd like a modern looking boilerplate. 
-  Clean type, sans-serif, and a nice color palette. 
-  
+  But we'd like a modern looking boilerplate.
+  Clean type, sans-serif, and a nice color palette.
+
 */
 
 body {
@@ -82,19 +82,29 @@ body {
     background: linear-gradient(to bottom, #fff 0%, #fff 100%);
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
   }
-  .toggle-checkbox:checked + & {
+  #over:not(:checked) + & {
     background: #56c080;
     &:before {
       left: 30px;
     }
   }
 }
-.toggle-checkbox {
+.toggle-radio {
+  /* make it visually hidden but still there for screen readers */
+  border: 0px;
+  clip: rect(0px, 0px, 0px, 0px);
+  clip-path: inset(50%);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0px;
   position: absolute;
-  visibility: hidden;
+  width: 1px;
+  white-space: nowrap;
 }
 .toggle-label {
   margin-left: 5px;
   position: relative;
   top: 2px;
+  cursor: pointer;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -47,6 +47,9 @@ body {
 .toggle {
   cursor: pointer;
   display: inline-block;
+  &:has(:focus-visible) {
+    outline: 2px solid blue;
+  }
 }
 
 .toggle:disabled {


### PR DESCRIPTION
Noticed that the switch was not usable with a screen reader. That's because the checkbox had `visibility: hidden` on it which also hides it from screen readers. Changed that to some styles that make it visually hidden but still there for assistive tech. Like this: https://tailwindcss.com/docs/screen-readers

That got it to announce, but it was hard to tell what the selected value was. It would read "It's so over we're so back, checked" for example 🤷. So I decided to turn it into two separate radio buttons so screen readers could tell which one was selected.